### PR TITLE
Replace to https git repo to not get blocked in install

### DIFF
--- a/docs/hub/getting-started/installation.md
+++ b/docs/hub/getting-started/installation.md
@@ -34,7 +34,7 @@ mkdir hub && cd hub
 Clone down the hub repository
 
 ```shell
-git clone git@github.com:getcandy/hub.git .
+git clone https://github.com/getcandy/hub.git  .
 ```
 
 Copy the example .env file


### PR DESCRIPTION
$ git clone git@github.com:getcandy/hub.git . 
=>
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

$ git clone https://github.com/getcandy/hub.git .
=>
Cloning into 'hub'...